### PR TITLE
[WIP] Add getblockstats RPC call

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -361,9 +361,9 @@ pub trait RpcApi: Sized {
         block_height: Option<usize>,
     ) -> Result<json::GetBlockStatsResult> {
         if let Some(hash) = block_hash {
-            self.call("getblockstats", &[into_json(hash)?, empty_arr()]).await
+            self.call("getblockstats", &[into_json(hash)?]).await
         } else if let Some(height) = block_height {
-            self.call("getblockstats", &[into_json(height)?, empty_arr()]).await
+            self.call("getblockstats", &[into_json(height)?]).await
         } else {
             panic!("TODO: Which error to use?")
         }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -361,9 +361,9 @@ pub trait RpcApi: Sized {
         block_height: Option<usize>,
     ) -> Result<json::GetBlockStatsResult> {
         if let Some(hash) = block_hash {
-            self.call("getblockstats", &[into_json(hash)?, true.into()]).await
+            self.call("getblockstats", &[into_json(hash)?]).await
         } else if let Some(height) = block_height {
-            self.call("getblockstats", &[into_json(height)?, true.into()]).await
+            self.call("getblockstats", &[into_json(height)?]).await
         } else {
             self.call("getblockstats", &[]).await
         }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -353,6 +353,22 @@ pub trait RpcApi: Sized {
         self.call("getblockheader", &[into_json(hash)?, true.into()]).await
     }
 
+    /// Compute per block statistics for a given window. All amounts are in satoshis.
+    /// https://developer.bitcoin.org/reference/rpc/getblockstats.html
+    async fn get_block_stats(
+        &self,
+        block_hash: Option<&bitcoin::BlockHash>,
+        block_height: Option<usize>,
+    ) -> Result<json::GetBlockStatsResult> {
+        if let Some(hash) = block_hash {
+            self.call("getblockstats", &[into_json(hash)?, true.into()]).await
+        } else if let Some(height) = block_height {
+            self.call("getblockstats", &[into_json(height)?, true.into()]).await
+        } else {
+            self.call("getblockstats", &[]).await
+        }
+    }
+
     async fn get_mining_info(&self) -> Result<json::GetMiningInfoResult> {
         self.call("getmininginfo", &[]).await
     }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -365,7 +365,7 @@ pub trait RpcApi: Sized {
         } else if let Some(height) = block_height {
             self.call("getblockstats", &[into_json(height)?]).await
         } else {
-            self.call("getblockstats", &[]).await
+            panic!("TODO: Which error to use?")
         }
     }
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -361,9 +361,9 @@ pub trait RpcApi: Sized {
         block_height: Option<usize>,
     ) -> Result<json::GetBlockStatsResult> {
         if let Some(hash) = block_hash {
-            self.call("getblockstats", &[into_json(hash)?]).await
+            self.call("getblockstats", &[into_json(hash)?, empty_arr()]).await
         } else if let Some(height) = block_height {
-            self.call("getblockstats", &[into_json(height)?]).await
+            self.call("getblockstats", &[into_json(height)?, empty_arr()]).await
         } else {
             panic!("TODO: Which error to use?")
         }

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -288,8 +288,8 @@ pub struct GetBlockStatsResult {
     pub time: u64,
     /// Total amount in all outputs (excluding coinbase and thus reward [ie subsidy + totalfee])
     #[serde(rename = "total_out")]
-    #[serde(with = "bitcoin::util::amount::serde::as_btc")]
-    pub total_out: Amount,
+    // #[serde(with = "bitcoin::util::amount::serde::as_btc")]
+    pub total_out: usize,
     /// Total size of all non-coinbase transactions
     #[serde(rename = "total_size")]
     pub total_size: usize,

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -269,6 +269,7 @@ pub struct GetBlockStatsResult {
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
     total_fee: Amount,
     txs: usize,
+    #[serde(rename = "utxo_increase")]
     utxo_increase: usize,
     utxo_size_inc: usize,
 }

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -259,7 +259,7 @@ pub struct GetBlockStatsResult {
     #[serde(rename = "swtxs")]
     sw_txs: usize,
     time: usize,
-    total_out: usize,
+    total_out: u64,
     total_size: usize,
     total_weight: usize,
     #[serde(rename = "totalfee")]

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -259,7 +259,8 @@ pub struct GetBlockStatsResult {
     #[serde(rename = "swtxs")]
     sw_txs: usize,
     time: usize,
-    total_out: u64,
+    #[serde(rename = "total_out")]
+    total_out: usize,
     total_size: usize,
     total_weight: usize,
     #[serde(rename = "totalfee")]

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -263,6 +263,7 @@ pub struct GetBlockStatsResult {
     total_out: usize,
     #[serde(rename = "total_size")]
     total_size: usize,
+    #[serde(rename = "total_weight")]
     total_weight: usize,
     #[serde(rename = "totalfee")]
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -259,9 +259,10 @@ pub struct GetBlockStatsResult {
     #[serde(rename = "swtxs")]
     sw_txs: usize,
     time: usize,
-    totalOut: usize,
+    total_out: usize,
     total_size: usize,
     total_weight: usize,
+    #[serde(rename = "totalfee")]
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
     total_fee: Amount,
     txs: usize,

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -219,90 +219,90 @@ pub struct GetBlockStatsResult {
     /// Average fee in the block
     #[serde(rename = "avgfee")]
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
-    avg_fee: Amount,
+    pub avg_fee: Amount,
     /// Average feerate (in satoshis per virtual byte)
     #[serde(rename = "avgfeerate")]
-    avg_fee_rate: usize,
+    pub avg_fee_rate: usize,
     /// Average transaction size
     #[serde(rename = "avgtxsize")]
-    avg_tx_size: u64,
+    pub avg_tx_size: u64,
     /// The block hash (to check for potential reorgs)
     #[serde(rename = "blockhash")]
-    block_hash: bitcoin::BlockHash,
+    pub block_hash: bitcoin::BlockHash,
     /// Feerates at the 10th, 25th, 50th, 75th, and 90th percentile weight unit (in satoshis per
     /// virtual byte)
     #[serde(rename = "feerate_percentiles")]
-    fee_rate_percentiles: [u8; 5],
+    pub fee_rate_percentiles: [u8; 5],
     /// The height of the block
-    height: usize,
+    pub height: usize,
     /// The number of inputs (excluding coinbase)
-    ins: usize,
+    pub ins: usize,
     /// Maximum fee in the block
     #[serde(rename = "maxfee")]
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
-    max_fee: Amount,
+    pub max_fee: Amount,
     /// Maximum feerate (in satoshis per virtual byte)
     #[serde(rename = "maxfeerate")]
-    max_fee_rate: usize,
+    pub max_fee_rate: usize,
     /// Maximum transaction size
     #[serde(rename = "maxtxsize")]
-    max_tx_size: usize,
+    pub max_tx_size: usize,
     /// Truncated median fee in the block
     #[serde(rename = "medianfee")]
-    median_fee: usize,
+    pub median_fee: usize,
     /// The block median time past
     #[serde(rename = "mediantime")]
-    median_time: usize,
+    pub median_time: usize,
     /// Truncated median transaction size
     #[serde(rename = "mediantxsize")]
-    median_tx_size: usize,
+    pub median_tx_size: usize,
     /// Minimum fee in the block
     #[serde(rename = "minfee")]
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
-    min_fee: Amount,
+    pub min_fee: Amount,
     /// Minimum feerate (in satoshis per virtual byte)
     #[serde(rename = "minfeerate")]
-    min_fee_rate: usize,
+    pub min_fee_rate: usize,
     /// Minimum transaction size
     #[serde(rename = "mintxsize")]
-    min_tx_size: usize,
+    pub min_tx_size: usize,
     /// The number of outputs
-    outs: usize,
+    pub outs: usize,
     /// The block subsidy
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
-    subsidy: Amount,
+    pub subsidy: Amount,
     /// Total size of all segwit transactions
     #[serde(rename = "swtotal_size")]
-    sw_total_size: usize,
+    pub sw_total_size: usize,
     /// Total weight of all segwit transactions
     #[serde(rename = "swtotal_weight")]
-    sw_total_weight: usize,
+    pub sw_total_weight: usize,
     /// The number of segwit transactions
     #[serde(rename = "swtxs")]
-    sw_txs: usize,
+    pub sw_txs: usize,
     /// The block time
-    time: usize,
+    pub time: usize,
     /// Total amount in all outputs (excluding coinbase and thus reward [ie subsidy + totalfee])
     #[serde(rename = "total_out")]
-    total_out: usize,
+    pub total_out: usize,
     /// Total size of all non-coinbase transactions
     #[serde(rename = "total_size")]
-    total_size: usize,
+    pub total_size: usize,
     /// Total weight of all non-coinbase transactions
     #[serde(rename = "total_weight")]
-    total_weight: usize,
+    pub total_weight: usize,
     /// The fee total
     #[serde(rename = "totalfee")]
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
-    total_fee: Amount,
+    pub total_fee: Amount,
     /// The number of transactions (including coinbase)
-    txs: usize,
+    pub txs: usize,
     /// The increase/decrease in the number of unspent outputs
     #[serde(rename = "utxo_increase")]
-    utxo_increase: usize,
+    pub utxo_increase: usize,
     /// The increase/decrease in size for the
     #[serde(rename = "utxo_size_inc")]
-    utxo_size_inc: usize,
+    pub utxo_size_inc: usize,
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -259,7 +259,7 @@ pub struct GetBlockStatsResult {
     #[serde(rename = "swtxs")]
     sw_txs: usize,
     time: usize,
-    total_out: usize,
+    totalOut: usize,
     total_size: usize,
     total_weight: usize,
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -222,10 +222,11 @@ pub struct GetBlockStatsResult {
     pub avg_fee: Amount,
     /// Average feerate (in satoshis per virtual byte)
     #[serde(rename = "avgfeerate")]
-    pub avg_fee_rate: usize,
+    #[serde(with = "bitcoin::util::amount::serde::as_btc")]
+    pub avg_fee_rate: Amount,
     /// Average transaction size
     #[serde(rename = "avgtxsize")]
-    pub avg_tx_size: u64,
+    pub avg_tx_size: u32,
     /// The block hash (to check for potential reorgs)
     #[serde(rename = "blockhash")]
     pub block_hash: bitcoin::BlockHash,
@@ -234,7 +235,7 @@ pub struct GetBlockStatsResult {
     #[serde(rename = "feerate_percentiles")]
     pub fee_rate_percentiles: [u8; 5],
     /// The height of the block
-    pub height: usize,
+    pub height: u64,
     /// The number of inputs (excluding coinbase)
     pub ins: usize,
     /// Maximum fee in the block
@@ -243,29 +244,32 @@ pub struct GetBlockStatsResult {
     pub max_fee: Amount,
     /// Maximum feerate (in satoshis per virtual byte)
     #[serde(rename = "maxfeerate")]
-    pub max_fee_rate: usize,
+    #[serde(with = "bitcoin::util::amount::serde::as_btc")]
+    pub max_fee_rate: Amount,
     /// Maximum transaction size
     #[serde(rename = "maxtxsize")]
-    pub max_tx_size: usize,
+    pub max_tx_size: u32,
     /// Truncated median fee in the block
     #[serde(rename = "medianfee")]
-    pub median_fee: usize,
+    #[serde(with = "bitcoin::util::amount::serde::as_btc")]
+    pub median_fee: Amount,
     /// The block median time past
     #[serde(rename = "mediantime")]
-    pub median_time: usize,
+    pub median_time: u64,
     /// Truncated median transaction size
     #[serde(rename = "mediantxsize")]
-    pub median_tx_size: usize,
+    pub median_tx_size: u32,
     /// Minimum fee in the block
     #[serde(rename = "minfee")]
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
     pub min_fee: Amount,
     /// Minimum feerate (in satoshis per virtual byte)
     #[serde(rename = "minfeerate")]
-    pub min_fee_rate: usize,
+    #[serde(with = "bitcoin::util::amount::serde::as_btc")]
+    pub min_fee_rate: Amount,
     /// Minimum transaction size
     #[serde(rename = "mintxsize")]
-    pub min_tx_size: usize,
+    pub min_tx_size: u32,
     /// The number of outputs
     pub outs: usize,
     /// The block subsidy
@@ -281,10 +285,11 @@ pub struct GetBlockStatsResult {
     #[serde(rename = "swtxs")]
     pub sw_txs: usize,
     /// The block time
-    pub time: usize,
+    pub time: u64,
     /// Total amount in all outputs (excluding coinbase and thus reward [ie subsidy + totalfee])
     #[serde(rename = "total_out")]
-    pub total_out: usize,
+    #[serde(with = "bitcoin::util::amount::serde::as_btc")]
+    pub total_out: Amount,
     /// Total size of all non-coinbase transactions
     #[serde(rename = "total_size")]
     pub total_size: usize,
@@ -299,10 +304,10 @@ pub struct GetBlockStatsResult {
     pub txs: usize,
     /// The increase/decrease in the number of unspent outputs
     #[serde(rename = "utxo_increase")]
-    pub utxo_increase: usize,
+    pub utxo_increase: i32,
     /// The increase/decrease in size for the
     #[serde(rename = "utxo_size_inc")]
-    pub utxo_size_inc: usize,
+    pub utxo_size_inc: i32,
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -13,9 +13,8 @@
 //! This is a client library for the Bitcoin Core JSON-RPC API.
 //!
 
-
-use std::collections::HashMap;
 pub use bitcoin;
+use std::collections::HashMap;
 
 use bitcoin::consensus::encode;
 use bitcoin::hashes::hex::{FromHex, ToHex};
@@ -210,6 +209,93 @@ pub struct GetBlockHeaderResult {
     pub previous_block_hash: Option<bitcoin::BlockHash>,
     #[serde(rename = "nextblockhash")]
     pub next_block_hash: Option<bitcoin::BlockHash>,
+}
+
+/// `getblockstats` RPC call.
+/// https://developer.bitcoin.org/reference/rpc/getblockstats.html
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetBlockStatsResult {
+    /// Average fee in the block
+    #[serde(rename = "avgfee")]
+    #[serde(with = "bitcoin::util::amount::serde::as_btc")]
+    avg_fee: Amount,
+    /// Average feerate (in satoshis per virtual byte)
+    #[serde(rename = "avgfeerate")]
+    avg_fee_rate: usize,
+    /// Average transaction size
+    #[serde(rename = "avgtxsize")]
+    avg_tx_size: u64,
+    ///  The block hash (to check for potential reorgs)
+    #[serde(rename = "blockhash")]
+    block_hash: bitcoin::BlockHash,
+    ///  Feerates at the 10th, 25th, 50th, 75th, and 90th percentile weight unit (in satoshis per
+    ///  virtual byte)
+    #[serde(rename = "feerate_percentiles")]
+    fee_rate_percentiles: [u8; 5],
+    ///  The height of the block
+    height: usize,
+    ///  The number of inputs (excluding coinbase)
+    ins: usize,
+    ///  Maximum fee in the block
+    #[serde(rename = "maxfee")]
+    #[serde(with = "bitcoin::util::amount::serde::as_btc")]
+    max_fee: Amount,
+    ///  Maximum feerate (in satoshis per virtual byte)
+    #[serde(rename = "maxfeerate")]
+    max_fee_rate: usize,
+    ///  Maximum transaction size
+    #[serde(rename = "maxtxsize")]
+    max_tx_size: usize,
+    ///  Truncated median fee in the block
+    #[serde(rename = "medianfee")]
+    median_fee: usize,
+    ///  The block median time past
+    #[serde(rename = "mediantime")]
+    median_time: usize,
+    ///  Truncated median transaction size
+    #[serde(rename = "mediantxsize")]
+    median_tx_size: usize,
+    ///  Minimum fee in the block
+    #[serde(rename = "minfee")]
+    #[serde(with = "bitcoin::util::amount::serde::as_btc")]
+    min_fee: Amount,
+    ///  Minimum feerate (in satoshis per virtual byte)
+    #[serde(rename = "minfeerate")]
+    min_fee_rate: usize,
+    ///  Minimum transaction size
+    #[serde(rename = "mintxsize")]
+    min_tx_size: usize,
+    ///  The number of outputs
+    outs: usize,
+    ///  The block subsidy
+    #[serde(with = "bitcoin::util::amount::serde::as_btc")]
+    subsidy: Amount,
+    ///  Total size of all segwit transactions
+    #[serde(rename = "swtotal_size")]
+    sw_total_size: usize,
+    ///  Total weight of all segwit transactions
+    #[serde(rename = "swtotal_weight")]
+    sw_total_weight: usize,
+    ///  The number of segwit transactions
+    sw_txs: usize,
+    ///  The block time
+    time: usize,
+    ///  Total amount in all outputs (excluding coinbase and thus reward [ie subsidy + totalfee])
+    total_out: usize,
+    ///  Total size of all non-coinbase transactions
+    total_size: usize,
+    ///  Total weight of all non-coinbase transactions
+    total_weight: usize,
+    ///  The fee total
+    #[serde(with = "bitcoin::util::amount::serde::as_btc")]
+    total_fee: Amount,
+    ///  The number of transactions (including coinbase)
+    txs: usize,
+    ///  The increase/decrease in the number of unspent outputs
+    utxo_increase: usize,
+    ///  The increase/decrease in size for the
+    utxo_size_inc: usize,
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -256,6 +256,7 @@ pub struct GetBlockStatsResult {
     sw_total_size: usize,
     #[serde(rename = "swtotal_weight")]
     sw_total_weight: usize,
+    #[serde(rename = "swtxs")]
     sw_txs: usize,
     time: usize,
     total_out: usize,

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -216,61 +216,91 @@ pub struct GetBlockHeaderResult {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBlockStatsResult {
+    /// Average fee in the block
     #[serde(rename = "avgfee")]
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
     avg_fee: Amount,
+    /// Average feerate (in satoshis per virtual byte)
     #[serde(rename = "avgfeerate")]
     avg_fee_rate: usize,
+    /// Average transaction size
     #[serde(rename = "avgtxsize")]
     avg_tx_size: u64,
+    /// The block hash (to check for potential reorgs)
     #[serde(rename = "blockhash")]
     block_hash: bitcoin::BlockHash,
+    /// Feerates at the 10th, 25th, 50th, 75th, and 90th percentile weight unit (in satoshis per
+    /// virtual byte)
     #[serde(rename = "feerate_percentiles")]
     fee_rate_percentiles: [u8; 5],
+    /// The height of the block
     height: usize,
+    /// The number of inputs (excluding coinbase)
     ins: usize,
+    /// Maximum fee in the block
     #[serde(rename = "maxfee")]
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
     max_fee: Amount,
+    /// Maximum feerate (in satoshis per virtual byte)
     #[serde(rename = "maxfeerate")]
     max_fee_rate: usize,
+    /// Maximum transaction size
     #[serde(rename = "maxtxsize")]
     max_tx_size: usize,
+    /// Truncated median fee in the block
     #[serde(rename = "medianfee")]
     median_fee: usize,
+    /// The block median time past
     #[serde(rename = "mediantime")]
     median_time: usize,
+    /// Truncated median transaction size
     #[serde(rename = "mediantxsize")]
     median_tx_size: usize,
+    /// Minimum fee in the block
     #[serde(rename = "minfee")]
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
     min_fee: Amount,
+    /// Minimum feerate (in satoshis per virtual byte)
     #[serde(rename = "minfeerate")]
     min_fee_rate: usize,
+    /// Minimum transaction size
     #[serde(rename = "mintxsize")]
     min_tx_size: usize,
+    /// The number of outputs
     outs: usize,
+    /// The block subsidy
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
     subsidy: Amount,
+    /// Total size of all segwit transactions
     #[serde(rename = "swtotal_size")]
     sw_total_size: usize,
+    /// Total weight of all segwit transactions
     #[serde(rename = "swtotal_weight")]
     sw_total_weight: usize,
+    /// The number of segwit transactions
     #[serde(rename = "swtxs")]
     sw_txs: usize,
+    /// The block time
     time: usize,
+    /// Total amount in all outputs (excluding coinbase and thus reward [ie subsidy + totalfee])
     #[serde(rename = "total_out")]
     total_out: usize,
+    /// Total size of all non-coinbase transactions
     #[serde(rename = "total_size")]
     total_size: usize,
+    /// Total weight of all non-coinbase transactions
     #[serde(rename = "total_weight")]
     total_weight: usize,
+    /// The fee total
     #[serde(rename = "totalfee")]
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
     total_fee: Amount,
+    /// The number of transactions (including coinbase)
     txs: usize,
+    /// The increase/decrease in the number of unspent outputs
     #[serde(rename = "utxo_increase")]
     utxo_increase: usize,
+    /// The increase/decrease in size for the
     #[serde(rename = "utxo_size_inc")]
     utxo_size_inc: usize,
 }

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -271,6 +271,7 @@ pub struct GetBlockStatsResult {
     txs: usize,
     #[serde(rename = "utxo_increase")]
     utxo_increase: usize,
+    #[serde(rename = "utxo_size_inc")]
     utxo_size_inc: usize,
 }
 

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -216,85 +216,55 @@ pub struct GetBlockHeaderResult {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBlockStatsResult {
-    /// Average fee in the block
     #[serde(rename = "avgfee")]
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
     avg_fee: Amount,
-    /// Average feerate (in satoshis per virtual byte)
     #[serde(rename = "avgfeerate")]
     avg_fee_rate: usize,
-    /// Average transaction size
     #[serde(rename = "avgtxsize")]
     avg_tx_size: u64,
-    ///  The block hash (to check for potential reorgs)
     #[serde(rename = "blockhash")]
     block_hash: bitcoin::BlockHash,
-    ///  Feerates at the 10th, 25th, 50th, 75th, and 90th percentile weight unit (in satoshis per
-    ///  virtual byte)
     #[serde(rename = "feerate_percentiles")]
     fee_rate_percentiles: [u8; 5],
-    ///  The height of the block
     height: usize,
-    ///  The number of inputs (excluding coinbase)
     ins: usize,
-    ///  Maximum fee in the block
     #[serde(rename = "maxfee")]
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
     max_fee: Amount,
-    ///  Maximum feerate (in satoshis per virtual byte)
     #[serde(rename = "maxfeerate")]
     max_fee_rate: usize,
-    ///  Maximum transaction size
     #[serde(rename = "maxtxsize")]
     max_tx_size: usize,
-    ///  Truncated median fee in the block
     #[serde(rename = "medianfee")]
     median_fee: usize,
-    ///  The block median time past
     #[serde(rename = "mediantime")]
     median_time: usize,
-    ///  Truncated median transaction size
     #[serde(rename = "mediantxsize")]
     median_tx_size: usize,
-    ///  Minimum fee in the block
     #[serde(rename = "minfee")]
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
     min_fee: Amount,
-    ///  Minimum feerate (in satoshis per virtual byte)
     #[serde(rename = "minfeerate")]
     min_fee_rate: usize,
-    ///  Minimum transaction size
     #[serde(rename = "mintxsize")]
     min_tx_size: usize,
-    ///  The number of outputs
     outs: usize,
-    ///  The block subsidy
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
     subsidy: Amount,
-    ///  Total size of all segwit transactions
     #[serde(rename = "swtotal_size")]
     sw_total_size: usize,
-    ///  Total weight of all segwit transactions
     #[serde(rename = "swtotal_weight")]
     sw_total_weight: usize,
-    ///  The number of segwit transactions
     sw_txs: usize,
-    ///  The block time
     time: usize,
-    ///  Total amount in all outputs (excluding coinbase and thus reward [ie subsidy + totalfee])
     total_out: usize,
-    ///  Total size of all non-coinbase transactions
     total_size: usize,
-    ///  Total weight of all non-coinbase transactions
     total_weight: usize,
-    ///  The fee total
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
     total_fee: Amount,
-    ///  The number of transactions (including coinbase)
     txs: usize,
-    ///  The increase/decrease in the number of unspent outputs
     utxo_increase: usize,
-    ///  The increase/decrease in size for the
     utxo_size_inc: usize,
 }
 

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -261,6 +261,7 @@ pub struct GetBlockStatsResult {
     time: usize,
     #[serde(rename = "total_out")]
     total_out: usize,
+    #[serde(rename = "total_size")]
     total_size: usize,
     total_weight: usize,
     #[serde(rename = "totalfee")]


### PR DESCRIPTION
Adds [`getblockstats`](https://developer.bitcoin.org/reference/rpc/getblockstats.html) RPC call.

- [x] `getblockstats` RPC call using block hash
- [x] `getblockstats` RPC call using block height
- [ ] Allow specification of optional `minfeerate` and/or `avgfeerate`
- [ ] Add integration test