### PR TITLE
Fix broken integration tests

### DIFF
--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -19,12 +19,12 @@ PID1=$!
 sleep 3
 
 BLOCKFILTERARG=""
-if bitcoind -version | grep -q "0\.19\|0\.20"; then
+if bitcoind -version | grep -q "v0\.\(19\|2\)"; then
     BLOCKFILTERARG="-blockfilterindex=1"
 fi
 
 FALLBACKFEEARG=""
-if bitcoind -version | grep -q "0\.20"; then
+if bitcoind -version | grep -q "v0\.2"; then
     FALLBACKFEEARG="-fallbackfee=0.00001000"
 fi
 
@@ -33,6 +33,7 @@ bitcoind -regtest $BLOCKFILTERARG $FALLBACKFEEARG \
     -connect=127.0.0.1:12348 \
     -rpcport=12349 \
     -server=1 \
+    -txindex=1 \
     -printtoconsole=0 &
 PID2=$!
 

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -228,6 +228,8 @@ async fn test_generate(cl: &Client) {
         assert_eq!(blocks.len(), 6);
     } else if version() < 190000 {
         assert_deprecated!(cl.generate(5, None));
+    } else if version() < 210000 {
+        assert_not_found!(cl.generate(5, None));
     } else {
         assert_not_found!(cl.generate(5, None));
     }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -110,7 +110,8 @@ fn get_auth() -> bitcoincore_rpc::Auth {
 async fn main() {
     log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::max())).unwrap();
 
-    let rpc_url = get_rpc_url();
+    // let rpc_url = get_rpc_url();
+    let rpc_url = format!("{}/wallet/testwallet", get_rpc_url());
     let auth = get_auth();
 
     let cl = Client::new(rpc_url, auth).await.unwrap();
@@ -118,6 +119,8 @@ async fn main() {
     test_get_network_info(&cl).await;
     unsafe { VERSION = cl.version().await.unwrap() };
     println!("Version: {}", version());
+
+    cl.create_wallet("testwallet", None, None, None, None).await.unwrap();
 
     test_get_mining_info(&cl).await;
     test_get_blockchain_info(&cl).await;


### PR DESCRIPTION
Many of the integration tests are broken for various reasons pertaining to the wallet. 

Some of these issues are fixed in the downstream `rust-bitcoincore-rpc` library in [this commit](https://github.com/rust-bitcoin/rust-bitcoincore-rpc/commit/ba256d76e343226325645811d79c0a413bbae731). This PR pulls in these changes and makes them asynchronous where needed.